### PR TITLE
Update README.md

### DIFF
--- a/k8s-1/runnig_pod/README.md
+++ b/k8s-1/runnig_pod/README.md
@@ -2,19 +2,24 @@
 
     microk8s.kubectl port-forward  --address 0.0.0.0 kuard  8080:8080
 
-    microk8s.kubectl exec kuard date
+    microk8s.kubectl exec kuard -- date
 
-    microk8s.kubectl exec -it kuard ash
+    microk8s.kubectl exec -it kuard -- ash
 
     microk8s.kubectl cp <pod-name>:/captures/capture3.txt ./capture3.txt
 
     microk8s.kubectl cp $HOME/config.txt <pod-name>:/config.txt
+    
+    == Cleanup ==
+    kubectl delete pods kuard
 
 ==Pod with health check==
 
 microk8s.kubectl create -f kuard-pod-health.yaml
 
-    # Details of the restart can be found with kubectl describe kuard.
+kubectl port-forward --address 0.0.0.0 pod/kuard 8080:8080
+
+    # Details of the restart can be found with kubectl describe pod/kuard.
 
     # Kubernetes also supports tcpSocket health checks that
     # open a TCP socket; if the connection is successful, the probe succeeds. This style of

--- a/k8s-1/service-discovery/deployment-bandicoot-prod.yaml
+++ b/k8s-1/service-discovery/deployment-bandicoot-prod.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bandicoot-prod
+  labels:
+    ver: "2"
+    app: bandicoot
+    env: prod 
+spec:
+  selector:
+    matchLabels:
+      ver: "2"
+      app: bandicoot
+      env: prod     
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        ver: "2"
+        app: bandicoot
+        env: prod     
+    spec:
+      containers:
+      - name: kuard
+        image: gcr.io/kuar-demo/kuard-amd64:2
+        ports: 
+        - containerPort: 8080


### PR DESCRIPTION
Syntax deprecation fixes (user '--' before a command)
Cleanup - delete kuard pod before creating new one with health check
Port-forward - in order to browse to the kuard-health dashboard